### PR TITLE
Add no-std test

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -10,6 +10,10 @@ cargo test --verbose --doc
 cargo doc --verbose --no-default-features
 cargo build --verbose --no-default-features
 
+# Validate no_std status
+rustup target add thumbv7em-none-eabihf
+cargo build --verbose --no-default-features --target thumbv7em-none-eabihf
+
 if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
     # these tests take forever, so only do them on nightly
     cargo test --verbose --test default

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -10,9 +10,13 @@ cargo test --verbose --doc
 cargo doc --verbose --no-default-features
 cargo build --verbose --no-default-features
 
-# Validate no_std status
-rustup target add thumbv7em-none-eabihf
-cargo build --verbose --no-default-features --target thumbv7em-none-eabihf
+# Validate no_std status if this version of rust supports
+#   embedded targets (starting with 1.31 stable)
+if rustup target add thumbv7em-none-eabihf ; then
+    cargo build --verbose --no-default-features --target thumbv7em-none-eabihf
+else
+    echo "Skipping no_std test..."
+fi
 
 if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
     # these tests take forever, so only do them on nightly


### PR DESCRIPTION
Hey! This is a small test addition that will validate that the crate maintains compatibility with no_std targets, by building for a microcontroller target.

I did check this locally, and it already passes, however adding it to CI will ensure that any dependencies do not introduce problems in the future!