### PR TITLE
[WIP] RegexSet-like functionality

### DIFF
--- a/src/dense.rs
+++ b/src/dense.rs
@@ -237,6 +237,8 @@ impl<S: StateID> DenseDFA<Vec<S>, S> {
     }
     /// fake
     pub fn dbg(&self) {
+        dbg!(&self.repr().start);
+        dbg!(&self.repr().state_count);
         dbg!(&self.repr().max_match);
         dbg!(&self.repr().match_map);
     }

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -235,13 +235,6 @@ impl<S: StateID> DenseDFA<Vec<S>, S> {
     pub fn empty() -> DenseDFA<Vec<S>, S> {
         Repr::empty().into_dense_dfa()
     }
-    /// fake
-    pub fn dbg(&self) {
-        dbg!(&self.repr().start);
-        dbg!(&self.repr().state_count);
-        dbg!(&self.repr().max_match);
-        dbg!(&self.repr().match_map);
-    }
 }
 
 impl<T: AsRef<[S]>, S: StateID> DenseDFA<T, S> {
@@ -1660,6 +1653,9 @@ impl<S: StateID> Repr<Vec<S>, S> {
         }
         self.max_match = S::from_usize(first_non_match - 1);
         matches.truncate(first_non_match);
+        for v in &mut matches {
+            v.sort_unstable();
+        }
         self.match_map = matches;
         assert!(self.match_map.iter().skip(1).all(|x| x.len() > 0), "invalid match map result");
     }

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -1938,6 +1938,12 @@ impl Builder {
         }
 
         let nfa = self.build_nfa(pattern)?;
+        
+        self.from_nfa(&nfa)
+    }
+    
+    /// Builds a DFA from the given NFA.
+    pub(crate) fn from_nfa<S: StateID>(&self, nfa: &NFA) -> Result<DenseDFA<Vec<S>, S>> {
         let mut dfa = if self.byte_classes {
             Determinizer::new(&nfa)
                 .with_byte_classes()
@@ -1952,6 +1958,7 @@ impl Builder {
         if self.premultiply {
             dfa.premultiply()?;
         }
+        
         Ok(dfa.into_dense_dfa())
     }
 

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -5,6 +5,10 @@ use core::iter;
 use core::mem;
 use core::slice;
 
+// @@awygle TEMP
+use std::vec;
+use std::vec::Vec;
+
 #[cfg(feature = "std")]
 use byteorder::{BigEndian, LittleEndian};
 use byteorder::{ByteOrder, NativeEndian};

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -1938,12 +1938,15 @@ impl Builder {
         }
 
         let nfa = self.build_nfa(pattern)?;
-        
+
         self.from_nfa(&nfa)
     }
-    
+
     /// Builds a DFA from the given NFA.
-    pub(crate) fn from_nfa<S: StateID>(&self, nfa: &NFA) -> Result<DenseDFA<Vec<S>, S>> {
+    pub(crate) fn from_nfa<S: StateID>(
+        &self,
+        nfa: &NFA,
+    ) -> Result<DenseDFA<Vec<S>, S>> {
         let mut dfa = if self.byte_classes {
             Determinizer::new(&nfa)
                 .with_byte_classes()
@@ -1958,7 +1961,7 @@ impl Builder {
         if self.premultiply {
             dfa.premultiply()?;
         }
-        
+
         Ok(dfa.into_dense_dfa())
     }
 

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -997,10 +997,10 @@ pub(crate) struct Repr<T, S> {
     ///
     /// In practice, T is either Vec<S> or &[S].
     trans: T,
-    
+
     /// A contiguous region of memory representing a map from match state index
     /// to pattern indexes which matched.
-    /// 
+    ///
     /// @@awygle TODO: make this generic and also (potentially) non-allocating.
     pub match_map: Vec<Vec<usize>>,
 }
@@ -1104,8 +1104,7 @@ impl<T: AsRef<[S]>, S: StateID> Repr<T, S> {
     pub fn match_indexes(&self, id: S) -> &[usize] {
         if !self.is_match_state(id) {
             &[]
-        }
-        else {
+        } else {
             &self.match_map[self.state_id_to_index(id)]
         }
     }
@@ -1618,7 +1617,9 @@ impl<S: StateID> Repr<Vec<S>, S> {
         }
 
         let mut first_non_match = 1;
-        while first_non_match < self.state_count && matches[first_non_match].len() > 0 {
+        while first_non_match < self.state_count
+            && matches[first_non_match].len() > 0
+        {
             first_non_match += 1;
         }
 
@@ -1635,7 +1636,9 @@ impl<S: StateID> Repr<Vec<S>, S> {
                 swaps[first_non_match] = S::from_usize(cur);
 
                 first_non_match += 1;
-                while first_non_match < cur && matches[first_non_match].len() > 0 {
+                while first_non_match < cur
+                    && matches[first_non_match].len() > 0
+                {
                     first_non_match += 1;
                 }
             }
@@ -1657,7 +1660,10 @@ impl<S: StateID> Repr<Vec<S>, S> {
             v.sort_unstable();
         }
         self.match_map = matches;
-        assert!(self.match_map.iter().skip(1).all(|x| x.len() > 0), "invalid match map result");
+        assert!(
+            self.match_map.iter().skip(1).all(|x| x.len() > 0),
+            "invalid match map result"
+        );
     }
 }
 

--- a/src/determinize.rs
+++ b/src/determinize.rs
@@ -55,7 +55,7 @@ struct State {
     /// Whether this state is a match state or not.
     is_match: bool,
     /// Which pattern this state is a match state for.
-    match_idx: usize,
+    match_idx: Vec<usize>,
     /// An ordered sequence of NFA states that make up this DFA state.
     nfa_states: Vec<nfa::StateID>,
 }
@@ -233,7 +233,7 @@ impl<'a, S: StateID> Determinizer<'a, S> {
     fn new_state(&mut self, set: &SparseSet) -> State {
         let mut state = State {
             is_match: false,
-            match_idx: 0,
+            match_idx: Vec::with_capacity(self.nfa.num_matches()),
             nfa_states: mem::replace(&mut self.scratch_nfa_states, vec![]),
         };
         state.nfa_states.clear();
@@ -245,7 +245,7 @@ impl<'a, S: StateID> Determinizer<'a, S> {
                 }
                 nfa::State::Match { match_idx } => {
                     state.is_match = true;
-                    state.match_idx = match_idx;
+                    state.match_idx.push(match_idx);
                     if !self.longest_match {
                         break;
                     }
@@ -265,6 +265,6 @@ impl<'a, S: StateID> Determinizer<'a, S> {
 impl State {
     /// Create a new empty dead state.
     fn dead() -> State {
-        State { nfa_states: vec![], is_match: false, match_idx: 0 }
+        State { nfa_states: vec![], is_match: false, match_idx: vec![] }
     }
 }

--- a/src/determinize.rs
+++ b/src/determinize.rs
@@ -243,7 +243,7 @@ impl<'a, S: StateID> Determinizer<'a, S> {
                 nfa::State::Match { match_idx } => {
                     state.match_idx.push(match_idx);
                     // gotta keep going if we have multiple matches to deal with
-                    if !self.longest_match /*&& !self.nfa.multi_match*/ {
+                    if !self.longest_match && !self.nfa.multi_match {
                         break;
                     }
                 }

--- a/src/determinize.rs
+++ b/src/determinize.rs
@@ -243,7 +243,7 @@ impl<'a, S: StateID> Determinizer<'a, S> {
                 nfa::State::Match { match_idx } => {
                     state.match_idx.push(match_idx);
                     // gotta keep going if we have multiple matches to deal with
-                    if !self.longest_match && !self.nfa.multi_match {
+                    if !self.longest_match /*&& !self.nfa.multi_match*/ {
                         break;
                     }
                 }

--- a/src/determinize.rs
+++ b/src/determinize.rs
@@ -189,7 +189,9 @@ impl<'a, S: StateID> Determinizer<'a, S> {
                 }
                 set.insert(id);
                 match *self.nfa.state(id) {
-                    nfa::State::Range { .. } | nfa::State::Match { .. } => break,
+                    nfa::State::Range { .. } | nfa::State::Match { .. } => {
+                        break
+                    }
                     nfa::State::Union { ref alternates } => {
                         id = match alternates.get(0) {
                             None => break,
@@ -241,7 +243,7 @@ impl<'a, S: StateID> Determinizer<'a, S> {
                 nfa::State::Range { .. } => {
                     state.nfa_states.push(id);
                 }
-                nfa::State::Match { match_idx }=> {
+                nfa::State::Match { match_idx } => {
                     state.is_match = true;
                     state.match_idx = match_idx;
                     if !self.longest_match {

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -295,26 +295,35 @@ pub trait DFA {
     /// The significance of the starting point is that it takes the surrounding
     /// context into consideration. For example, if the DFA is anchored, then
     /// a match can only occur when `start == 0`.
-    /// 
+    ///
     /// The significance of the starting state is to resume on overlapping matches.
     #[inline]
-    fn overlapping_find_at(&self, bytes: &[u8], start_index: usize, cur_state: &mut Self::ID, match_index: &mut usize) -> Option<(usize, usize)> {
-        if self.is_anchored() && start_index > 0 && *cur_state == self.start_state() {
+    fn overlapping_find_at(
+        &self,
+        bytes: &[u8],
+        start_index: usize,
+        cur_state: &mut Self::ID,
+        match_index: &mut usize,
+    ) -> Option<(usize, usize)> {
+        if self.is_anchored()
+            && start_index > 0
+            && *cur_state == self.start_state()
+        {
             return None;
         }
 
         let matches = self.match_indexes(*cur_state);
         let mut state = *cur_state;
         if self.is_dead_state(state) {
-            return None ;
+            return None;
         } else if self.is_match_state(state) && *match_index < matches.len() {
             let result = matches[*match_index];
             *match_index += 1;
             return Some((start_index, result));
         }
-        
+
         *match_index = 0;
-        
+
         for (i, &b) in bytes[start_index..].iter().enumerate() {
             state = unsafe { self.next_state_unchecked(state, b) };
             *cur_state = state;

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -266,26 +266,37 @@ pub trait DFA {
     #[inline]
     fn find_at(&self, bytes: &[u8], start: usize) -> Option<usize> {
         if self.is_anchored() && start > 0 {
+            println!("anchor early out");
             return None;
         }
 
         let mut state = self.start_state();
         let mut last_match = if self.is_dead_state(state) {
+            println!("currently in dead state, die");
             return None;
         } else if self.is_match_state(state) {
+            println!("currently in match state, just return match");
             Some(start)
         } else {
+            println!("not currently in match state");
             None
         };
         for (i, &b) in bytes[start..].iter().enumerate() {
+            dbg!(i);
+            dbg!(b);
+            dbg!(state);
             state = unsafe { self.next_state_unchecked(state, b) };
+            dbg!(state);
             if self.is_match_or_dead_state(state) {
                 if self.is_dead_state(state) {
+                    println!("returning {:?}", last_match);
                     return last_match;
                 }
+                println!("saving match at {}", start+i+1);
                 last_match = Some(start + i + 1);
             }
         }
+        println!("returning {:?} at end of input", last_match);
         last_match
     }
 
@@ -300,54 +311,48 @@ pub trait DFA {
     #[inline]
     fn overlapping_find_at(&self, bytes: &[u8], start_index: usize, cur_state: &mut Self::ID, match_index: &mut usize) -> Option<(usize, usize)> {
         if self.is_anchored() && start_index > 0 && *cur_state == self.start_state() {
-            println!("anchor early out");
             return None;
         }
 
         let matches = self.match_indexes(*cur_state);
-        if *match_index < matches.len() {
-            println!("currently in match state, just return match");
-            let result = matches[*match_index];
-            println!("incrementing match index");
-            *match_index += 1;
-            return Some((start_index, result));
-        }
+        let mut state = *cur_state;
+        let mut last_match = if self.is_dead_state(state) {
+                state = self.start_state();
+                None 
+            } else if self.is_match_state(state) && *match_index < matches.len() {
+                let result = matches[*match_index];
+                *match_index += 1;
+                Some((start_index, result))
+            }
+            else {
+                None
+            };
         
-        println!("not currently in match state, setting match index to 0");
         *match_index = 0;
         
-        let mut state = *cur_state;
-        if self.is_match_or_dead_state(state) {
-            if self.is_dead_state(state) { 
-                return None; 
-            } else {
-                *match_index += 1;
-                return Some((start_index, *match_index-1))
-            }
-        }
-        
         for (i, &b) in bytes[start_index..].iter().enumerate() {
-            state = unsafe { self.next_state_unchecked(state, b) };
             dbg!(i);
             dbg!(b);
             dbg!(state);
-            dbg!(self.is_match_state(state));
-            dbg!(self.match_indexes(state));
+            state = unsafe { self.next_state_unchecked(state, b) };
+            *cur_state = state;
+            dbg!(state);
             if self.is_match_or_dead_state(state) {
-                return if self.is_dead_state(state) {
-                    println!("returning None");
-                    None
+                if self.is_dead_state(state) {
+                    println!("returning {:?}", last_match);
+                    return last_match;
+                    //state = self.start_state();
                 } else {
-                    println!("incrementing match index in inner loop");
+                    println!("saving match at {}", start_index+i+1);
                     let matches = self.match_indexes(state);
                     let result = matches[*match_index];
                     *match_index += 1;
-                    Some((start_index + i + 1, result))
+                    last_match = Some((start_index + i + 1, result))
                 }
             }
         }
-        println!("returning None at end of input");
-        None
+        println!("returning {:?} at end of input", last_match);
+        last_match
     }
 
     /// Returns the same as `rfind`, but starts the search at the given

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -24,7 +24,7 @@ pub struct NFA {
     /// The starting state of this NFA.
     start: StateID,
     /// The state list. This list is guaranteed to be indexable by the starting
-    /// state ID, and it is also guaranteed to contain exactly one `Match`
+    /// state ID, and it is also guaranteed to contain at least one `Match`
     /// state.
     states: Vec<State>,
     /// A mapping from any byte value to its corresponding equivalence class
@@ -48,7 +48,7 @@ pub enum State {
     /// states in `alternates`, where matches found via earlier transitions
     /// are preferred over later transitions.
     Union { alternates: Vec<StateID> },
-    /// A match state. There is exactly one such occurrence of this state in
+    /// A match state. There is at least one such occurrence of this state in
     /// an NFA.
     Match { match_idx: usize },
 }
@@ -79,6 +79,17 @@ impl NFA {
     /// corresponding equivalence class ID (which is never more than 255).
     pub fn byte_classes(&self) -> &ByteClasses {
         &self.byte_classes
+    }
+
+    /// Returns the number of match states in this NFA.
+    pub fn num_matches(&self) -> usize {
+        self.states
+            .iter()
+            .filter(|s| match s {
+                State::Match { .. } => true,
+                _ => false,
+            })
+            .count()
     }
 }
 
@@ -284,7 +295,7 @@ enum BState {
     /// into one Union type of state, where the latter has its epsilon
     /// transitions reversed to reflect the priority inversion.
     UnionReverse { alternates: Vec<StateID> },
-    /// A match state. There is exactly one such occurrence of this state in
+    /// A match state. There is at least one such occurrence of this state in
     /// an NFA.
     Match { match_idx: usize },
 }

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -171,7 +171,8 @@ impl NFABuilder {
         let match_id = compiler.add_match(0);
         compiler.patch(start, compiled.start);
         compiler.patch(compiled.end, match_id);
-        let result = Ok(NFA { anchored: self.anchored, ..compiler.to_nfa(false) });
+        let result =
+            Ok(NFA { anchored: self.anchored, ..compiler.to_nfa(false) });
         return result;
     }
 
@@ -191,9 +192,9 @@ impl NFABuilder {
         };
 
         let start = compiler.add_empty();
-        
+
         let u = compiler.add_union();
-        
+
         for (i, expr) in exprs.into_iter().enumerate() {
             let mut pattern_start = u;
             // have to deal with anchoring per-pattern
@@ -206,16 +207,17 @@ impl NFABuilder {
                 compiler.patch(u, compiled.start);
                 pattern_start = compiled.end;
             }
-            
+
             let compiled_pattern = compiler.compile(&expr)?;
             let match_id = compiler.add_match(i);
             compiler.patch(compiled_pattern.end, match_id);
             compiler.patch(pattern_start, compiled_pattern.start);
         }
-        
+
         compiler.patch(start, u);
-        
-        let result = Ok(NFA { anchored: self.anchored, ..compiler.to_nfa(true) });
+
+        let result =
+            Ok(NFA { anchored: self.anchored, ..compiler.to_nfa(true) });
         return result;
     }
 
@@ -384,7 +386,13 @@ impl NFACompiler {
         }
         // The compiler always begins the NFA at the first state.
         let byte_classes = byteset.byte_classes();
-        NFA { anchored: false, start: remap[0], states, byte_classes, multi_match }
+        NFA {
+            anchored: false,
+            start: remap[0],
+            states,
+            byte_classes,
+            multi_match,
+        }
     }
 
     fn compile(&self, expr: &Hir) -> Result<ThompsonRef> {

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -7,6 +7,10 @@ use core::mem::size_of;
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 
+// @@awygle TEMP
+use std::vec;
+use std::vec::Vec;
+
 #[cfg(feature = "std")]
 use byteorder::{BigEndian, LittleEndian};
 use byteorder::{ByteOrder, NativeEndian};

--- a/tests/suite.rs
+++ b/tests/suite.rs
@@ -1,5 +1,5 @@
-use regex_automata::{DenseDFA, Regex, RegexBuilder, SparseDFA, DFA};
 use regex_automata::dense;
+use regex_automata::{DenseDFA, Regex, RegexBuilder, SparseDFA, DFA};
 
 use collection::{RegexTester, SUITE};
 
@@ -225,103 +225,107 @@ fn sparse_serialization_roundtrip() {
 #[test]
 fn multi_is_match() {
     let mut builder = dense::Builder::new();
-    
+
     // A single matching pattern
     let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
     assert!(dfa.is_match(b"a"));
-    
+
     // A single non-matching pattern
     let dfa = builder.build_multi_with_size::<usize>(vec!["b"]).unwrap();
     assert!(!dfa.is_match(b"a"));
-    
+
     // A single matching pattern not at start
     let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
     assert!(dfa.is_match(b"ba"));
-    
+
     // Multiple matching patterns
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     assert!(dfa.is_match(b"ab"));
-    
+
     // First pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     assert!(dfa.is_match(b"a"));
-    
+
     // Second pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     assert!(dfa.is_match(b"b"));
-    
+
     // Neither pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     assert!(!dfa.is_match(b"c"));
-    
+
     // Determinization edge case
     builder.anchored(true);
-    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    let dfa =
+        builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
     assert!(dfa.is_match(b"ac"));
-    
+
     // Anchored respected
-    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    let dfa =
+        builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
     assert!(!dfa.is_match(b"bac"));
 }
 
 #[test]
 fn multi_shortest_match() {
     let mut builder = dense::Builder::new();
-    
+
     // A single matching pattern
     let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
     assert_eq!(Some(1), dfa.shortest_match(b"a"));
-    
+
     // A single non-matching pattern
     let dfa = builder.build_multi_with_size::<usize>(vec!["b"]).unwrap();
     assert_eq!(None, dfa.shortest_match(b"a"));
-    
+
     // A single matching pattern not at start
     let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
     assert_eq!(Some(2), dfa.shortest_match(b"ba"));
-    
+
     // Multiple matching patterns
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     assert_eq!(Some(4), dfa.shortest_match(b"dddadddb"));
-    
+
     // First pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     assert_eq!(Some(1), dfa.shortest_match(b"a"));
-    
+
     // Second pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     assert_eq!(Some(1), dfa.shortest_match(b"b"));
-    
+
     // Neither pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     assert_eq!(None, dfa.shortest_match(b"c"));
-    
+
     // Determinization edge case
     builder.anchored(true);
-    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    let dfa =
+        builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
     assert_eq!(Some(2), dfa.shortest_match(b"ac"));
-    
+
     // Anchored respected
-    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    let dfa =
+        builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
     assert_eq!(None, dfa.shortest_match(b"bac"));
 }
 
 #[test]
 fn multi_find() {
     let mut builder = dense::Builder::new();
-    
+
     // A single matching pattern
     let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
     assert_eq!(Some(1), dfa.find(b"a"));
-    
+
     // A single non-matching pattern
     let dfa = builder.build_multi_with_size::<usize>(vec!["b"]).unwrap();
     assert_eq!(None, dfa.find(b"a"));
-    
+
     // A single matching pattern not at start
     let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
     assert_eq!(Some(2), dfa.find(b"ba"));
-    
+
     // Multiple matching patterns
     builder.premultiply(false);
     builder.unicode(false);
@@ -331,31 +335,33 @@ fn multi_find() {
     dfa.dbg();
     // @@awygle I'm not sure find actually has meaningful semantics for regex-set
     assert_eq!(Some(8), dfa.find(b"dddadddb"));
-    
+
     // Same pattern multiple times
     let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
     // @@awygle I'm not sure find actually has meaningful semantics for regex-set
     assert_eq!(Some(6), dfa.find(b"bababa"));
-    
+
     // First pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     assert_eq!(Some(1), dfa.find(b"a"));
-    
+
     // Second pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     assert_eq!(Some(1), dfa.find(b"b"));
-    
+
     // Neither pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     assert_eq!(None, dfa.find(b"c"));
-    
+
     // Determinization edge case
     builder.anchored(true);
-    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    let dfa =
+        builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
     assert_eq!(Some(2), dfa.find(b"ac"));
-    
+
     // Anchored respected
-    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    let dfa =
+        builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
     assert_eq!(None, dfa.find(b"bac"));
 }
 
@@ -363,153 +369,288 @@ fn multi_find() {
 fn multi_rfind() {
     let mut builder = dense::Builder::new();
     builder.reverse(true);
-    
+
     // A single matching pattern
     let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
     assert_eq!(Some(0), dfa.rfind(b"a"));
-    
+
     // A single non-matching pattern
     let dfa = builder.build_multi_with_size::<usize>(vec!["b"]).unwrap();
     assert_eq!(None, dfa.rfind(b"a"));
-    
+
     // A single matching pattern not at start
     let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
     assert_eq!(Some(1), dfa.rfind(b"ba"));
-    
+
     // Multiple matching patterns
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     // @@awygle I'm not sure rfind actually has meaningful semantics for regex-set
     assert_eq!(Some(3), dfa.rfind(b"dddadddb"));
-    
+
     // First pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     assert_eq!(Some(0), dfa.rfind(b"a"));
-    
+
     // Second pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     assert_eq!(Some(0), dfa.rfind(b"b"));
-    
+
     // Neither pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     assert_eq!(None, dfa.rfind(b"c"));
-    
+
     // Determinization edge case
     builder.anchored(true);
-    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    let dfa =
+        builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
     assert_eq!(Some(0), dfa.rfind(b"ac"));
-    
+
     // Anchored respected
-    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    let dfa =
+        builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
     assert_eq!(None, dfa.rfind(b"acb"));
 }
 
 #[test]
 fn overlapping_find_at() {
     let mut builder = dense::Builder::new();
-    
+
     // A single matching pattern
     let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
     let mut state = dfa.start_state();
     let mut match_index = 0;
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"a", 0, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(b"a", 0, &mut state, &mut match_index)
+        .unwrap();
     assert_eq!((1, 0), (input_idx, match_idx));
-    assert_eq!(None, dfa.overlapping_find_at(b"a", input_idx, &mut state, &mut match_index));
-    
+    assert_eq!(
+        None,
+        dfa.overlapping_find_at(b"a", input_idx, &mut state, &mut match_index)
+    );
+
     // A single non-matching pattern
     let dfa = builder.build_multi_with_size::<usize>(vec!["b"]).unwrap();
     let mut state = dfa.start_state();
     let mut match_index = 0;
-    assert_eq!(None, dfa.overlapping_find_at(b"a", 0, &mut state, &mut match_index));
-    
+    assert_eq!(
+        None,
+        dfa.overlapping_find_at(b"a", 0, &mut state, &mut match_index)
+    );
+
     // A single matching pattern not at start
     let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
     let mut state = dfa.start_state();
     let mut match_index = 0;
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"ba", 0, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(b"ba", 0, &mut state, &mut match_index)
+        .unwrap();
     assert_eq!((2, 0), (input_idx, match_idx));
-    assert_eq!(None, dfa.overlapping_find_at(b"ba", input_idx, &mut state, &mut match_index));
-    
+    assert_eq!(
+        None,
+        dfa.overlapping_find_at(
+            b"ba",
+            input_idx,
+            &mut state,
+            &mut match_index
+        )
+    );
+
     // Same pattern multiple times
     let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
     let mut state = dfa.start_state();
     let mut match_index = 0;
     let input_idx = 0;
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(
+            b"bababa",
+            input_idx,
+            &mut state,
+            &mut match_index,
+        )
+        .unwrap();
     assert_eq!((2, 0), (input_idx, match_idx));
     println!("got one");
     dbg!(input_idx);
     dbg!(match_index);
     dbg!(state);
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(
+            b"bababa",
+            input_idx,
+            &mut state,
+            &mut match_index,
+        )
+        .unwrap();
     assert_eq!((4, 0), (input_idx, match_idx));
     println!("got two");
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(
+            b"bababa",
+            input_idx,
+            &mut state,
+            &mut match_index,
+        )
+        .unwrap();
     assert_eq!((6, 0), (input_idx, match_idx));
     println!("got three");
-    assert_eq!(None, dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index));
-    
+    assert_eq!(
+        None,
+        dfa.overlapping_find_at(
+            b"bababa",
+            input_idx,
+            &mut state,
+            &mut match_index
+        )
+    );
+
     // multiple matching patterns
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     let mut state = dfa.start_state();
     let mut match_index = 0;
     let input_idx = 0;
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"dddadddb", input_idx, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(
+            b"dddadddb",
+            input_idx,
+            &mut state,
+            &mut match_index,
+        )
+        .unwrap();
     assert_eq!((4, 0), (input_idx, match_idx));
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"dddadddb", input_idx, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(
+            b"dddadddb",
+            input_idx,
+            &mut state,
+            &mut match_index,
+        )
+        .unwrap();
     assert_eq!((8, 1), (input_idx, match_idx));
-    assert_eq!(None, dfa.overlapping_find_at(b"dddadddb", input_idx, &mut state, &mut match_index));
-    
+    assert_eq!(
+        None,
+        dfa.overlapping_find_at(
+            b"dddadddb",
+            input_idx,
+            &mut state,
+            &mut match_index
+        )
+    );
+
     // First pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     let mut state = dfa.start_state();
     let mut match_index = 0;
     let input_idx = 0;
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"a", input_idx, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(b"a", input_idx, &mut state, &mut match_index)
+        .unwrap();
     assert_eq!((1, 0), (input_idx, match_idx));
-    assert_eq!(None, dfa.overlapping_find_at(b"a", input_idx, &mut state, &mut match_index));
-    
+    assert_eq!(
+        None,
+        dfa.overlapping_find_at(b"a", input_idx, &mut state, &mut match_index)
+    );
+
     // Second pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     let mut state = dfa.start_state();
     let mut match_index = 0;
     let input_idx = 0;
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"b", input_idx, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(b"b", input_idx, &mut state, &mut match_index)
+        .unwrap();
     assert_eq!((1, 1), (input_idx, match_idx));
-    assert_eq!(None, dfa.overlapping_find_at(b"b", input_idx, &mut state, &mut match_index));
-    
+    assert_eq!(
+        None,
+        dfa.overlapping_find_at(b"b", input_idx, &mut state, &mut match_index)
+    );
+
     // Neither pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
     let mut state = dfa.start_state();
     let mut match_index = 0;
     let input_idx = 0;
-    assert_eq!(None, dfa.overlapping_find_at(b"c", input_idx, &mut state, &mut match_index));
-    
+    assert_eq!(
+        None,
+        dfa.overlapping_find_at(b"c", input_idx, &mut state, &mut match_index)
+    );
+
     // Legit overlap
     builder.premultiply(false);
-    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "bc", "abc"]).unwrap();
+    let dfa = builder
+        .build_multi_with_size::<usize>(vec!["ab", "bc", "abc"])
+        .unwrap();
     dfa.dbg();
     let mut state = dfa.start_state();
     let mut match_index = 0;
     let input_idx = 0;
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(
+            b"abcabc",
+            input_idx,
+            &mut state,
+            &mut match_index,
+        )
+        .unwrap();
     assert_eq!((2, 0), (input_idx, match_idx));
     println!("one done");
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(
+            b"abcabc",
+            input_idx,
+            &mut state,
+            &mut match_index,
+        )
+        .unwrap();
     assert_eq!((3, 1), (input_idx, match_idx));
     println!("two done");
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(
+            b"abcabc",
+            input_idx,
+            &mut state,
+            &mut match_index,
+        )
+        .unwrap();
     assert_eq!((3, 2), (input_idx, match_idx));
     println!("three done");
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(
+            b"abcabc",
+            input_idx,
+            &mut state,
+            &mut match_index,
+        )
+        .unwrap();
     assert_eq!((5, 0), (input_idx, match_idx));
     println!("four done");
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(
+            b"abcabc",
+            input_idx,
+            &mut state,
+            &mut match_index,
+        )
+        .unwrap();
     assert_eq!((6, 1), (input_idx, match_idx));
     println!("five done");
-    let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
+    let (input_idx, match_idx) = dfa
+        .overlapping_find_at(
+            b"abcabc",
+            input_idx,
+            &mut state,
+            &mut match_index,
+        )
+        .unwrap();
     assert_eq!((6, 2), (input_idx, match_idx));
     println!("six done");
-    assert_eq!(None, dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index));
+    assert_eq!(
+        None,
+        dfa.overlapping_find_at(
+            b"abcabc",
+            input_idx,
+            &mut state,
+            &mut match_index
+        )
+    );
     println!("all done");
-    
 }

--- a/tests/suite.rs
+++ b/tests/suite.rs
@@ -1,4 +1,5 @@
-use regex_automata::{DenseDFA, Regex, RegexBuilder, SparseDFA};
+use regex_automata::{DenseDFA, Regex, RegexBuilder, SparseDFA, DFA};
+use regex_automata::dense;
 
 use collection::{RegexTester, SUITE};
 
@@ -219,4 +220,277 @@ fn sparse_serialization_roundtrip() {
         tester.test(test, &re);
     }
     tester.assert();
+}
+
+#[test]
+fn multi_is_match() {
+    let mut builder = dense::Builder::new();
+    
+    // A single matching pattern
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+    assert!(dfa.is_match(b"a"));
+    
+    // A single non-matching pattern
+    let dfa = builder.build_multi_with_size::<usize>(vec!["b"]).unwrap();
+    assert!(!dfa.is_match(b"a"));
+    
+    // A single matching pattern not at start
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+    assert!(dfa.is_match(b"ba"));
+    
+    // Multiple matching patterns
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert!(dfa.is_match(b"ab"));
+    
+    // First pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert!(dfa.is_match(b"a"));
+    
+    // Second pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert!(dfa.is_match(b"b"));
+    
+    // Neither pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert!(!dfa.is_match(b"c"));
+    
+    // Determinization edge case
+    builder.anchored(true);
+    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    assert!(dfa.is_match(b"ac"));
+    
+    // Anchored respected
+    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    assert!(!dfa.is_match(b"bac"));
+}
+
+#[test]
+fn multi_shortest_match() {
+    let mut builder = dense::Builder::new();
+    
+    // A single matching pattern
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+    assert_eq!(Some(1), dfa.shortest_match(b"a"));
+    
+    // A single non-matching pattern
+    let dfa = builder.build_multi_with_size::<usize>(vec!["b"]).unwrap();
+    assert_eq!(None, dfa.shortest_match(b"a"));
+    
+    // A single matching pattern not at start
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+    assert_eq!(Some(2), dfa.shortest_match(b"ba"));
+    
+    // Multiple matching patterns
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert_eq!(Some(4), dfa.shortest_match(b"dddadddb"));
+    
+    // First pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert_eq!(Some(1), dfa.shortest_match(b"a"));
+    
+    // Second pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert_eq!(Some(1), dfa.shortest_match(b"b"));
+    
+    // Neither pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert_eq!(None, dfa.shortest_match(b"c"));
+    
+    // Determinization edge case
+    builder.anchored(true);
+    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    assert_eq!(Some(2), dfa.shortest_match(b"ac"));
+    
+    // Anchored respected
+    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    assert_eq!(None, dfa.shortest_match(b"bac"));
+}
+
+#[test]
+fn multi_find() {
+    let mut builder = dense::Builder::new();
+    
+    // A single matching pattern
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+    assert_eq!(Some(1), dfa.find(b"a"));
+    
+    // A single non-matching pattern
+    let dfa = builder.build_multi_with_size::<usize>(vec!["b"]).unwrap();
+    assert_eq!(None, dfa.find(b"a"));
+    
+    // A single matching pattern not at start
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+    assert_eq!(Some(2), dfa.find(b"ba"));
+    
+    // Same pattern multiple times
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+    assert_eq!(Some(2), dfa.find(b"bababa"));
+    
+    // Multiple matching patterns
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert_eq!(Some(8), dfa.find(b"dddadddb"));
+    
+    // First pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert_eq!(Some(1), dfa.find(b"a"));
+    
+    // Second pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert_eq!(Some(1), dfa.find(b"b"));
+    
+    // Neither pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert_eq!(None, dfa.find(b"c"));
+    
+    // Determinization edge case
+    builder.anchored(true);
+    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    assert_eq!(Some(2), dfa.find(b"ac"));
+    
+    // Anchored respected
+    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    assert_eq!(None, dfa.find(b"bac"));
+}
+
+#[test]
+fn multi_rfind() {
+    let mut builder = dense::Builder::new();
+    builder.reverse(true);
+    
+    // A single matching pattern
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+    assert_eq!(Some(0), dfa.rfind(b"a"));
+    
+    // A single non-matching pattern
+    let dfa = builder.build_multi_with_size::<usize>(vec!["b"]).unwrap();
+    assert_eq!(None, dfa.rfind(b"a"));
+    
+    // A single matching pattern not at start
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+    assert_eq!(Some(1), dfa.rfind(b"ba"));
+    
+    // Multiple matching patterns
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert_eq!(Some(3), dfa.rfind(b"dddadddb"));
+    
+    // First pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert_eq!(Some(0), dfa.rfind(b"a"));
+    
+    // Second pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert_eq!(Some(0), dfa.rfind(b"b"));
+    
+    // Neither pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    assert_eq!(None, dfa.rfind(b"c"));
+    
+    // Determinization edge case
+    builder.anchored(true);
+    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    assert_eq!(Some(0), dfa.rfind(b"ac"));
+    
+    // Anchored respected
+    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "ac"]).unwrap();
+    assert_eq!(None, dfa.rfind(b"acb"));
+}
+
+#[test]
+fn overlapping_find_at() {
+    let mut builder = dense::Builder::new();
+    builder.reverse(true);
+    
+    // A single matching pattern
+//    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+//    let mut state = dfa.start_state();
+//    let mut match_index = 0;
+//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"a", 0, &mut state, &mut match_index).unwrap();
+//    assert_eq!((1, 0), (input_idx, match_idx));
+//    assert_eq!(None, dfa.overlapping_find_at(b"a", input_idx, &mut state, &mut match_index));
+//    
+//    // A single non-matching pattern
+//    let dfa = builder.build_multi_with_size::<usize>(vec!["b"]).unwrap();
+//    let mut state = dfa.start_state();
+//    let mut match_index = 0;
+//    assert_eq!(None, dfa.overlapping_find_at(b"a", 0, &mut state, &mut match_index));
+//    
+//    // A single matching pattern not at start
+//    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+//    let mut state = dfa.start_state();
+//    let mut match_index = 0;
+//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"ba", 0, &mut state, &mut match_index).unwrap();
+//    assert_eq!((2, 0), (input_idx, match_idx));
+//    assert_eq!(None, dfa.overlapping_find_at(b"ba", input_idx, &mut state, &mut match_index));
+//    
+//    // Same pattern multiple times
+//    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+//    let mut state = dfa.start_state();
+//    let mut match_index = 0;
+//    let input_idx = 0;
+//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index).unwrap();
+//    assert_eq!((2, 0), (input_idx, match_idx));
+//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index).unwrap();
+//    assert_eq!((4, 0), (input_idx, match_idx));
+//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index).unwrap();
+//    assert_eq!((6, 0), (input_idx, match_idx));
+//    assert_eq!(None, dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index));
+//    
+//    // multiple matching patterns
+//    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+//    let mut state = dfa.start_state();
+//    let mut match_index = 0;
+//    let input_idx = 0;
+//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"dddadddb", input_idx, &mut state, &mut match_index).unwrap();
+//    assert_eq!((4, 0), (input_idx, match_idx));
+//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"dddadddb", input_idx, &mut state, &mut match_index).unwrap();
+//    assert_eq!((8, 1), (input_idx, match_idx));
+//    assert_eq!(None, dfa.overlapping_find_at(b"dddadddb", input_idx, &mut state, &mut match_index));
+//    
+//    // First pattern matches
+//    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+//    let mut state = dfa.start_state();
+//    let mut match_index = 0;
+//    let input_idx = 0;
+//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"a", input_idx, &mut state, &mut match_index).unwrap();
+//    assert_eq!((1, 0), (input_idx, match_idx));
+//    assert_eq!(None, dfa.overlapping_find_at(b"a", input_idx, &mut state, &mut match_index));
+//    
+//    // Second pattern matches
+//    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+//    let mut state = dfa.start_state();
+//    let mut match_index = 0;
+//    let input_idx = 0;
+//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"b", input_idx, &mut state, &mut match_index).unwrap();
+//    assert_eq!((1, 1), (input_idx, match_idx));
+//    assert_eq!(None, dfa.overlapping_find_at(b"b", input_idx, &mut state, &mut match_index));
+//    
+//    // Neither pattern matches
+//    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+//    let mut state = dfa.start_state();
+//    let mut match_index = 0;
+//    let input_idx = 0;
+//    assert_eq!(None, dfa.overlapping_find_at(b"c", input_idx, &mut state, &mut match_index));
+    
+    // Legit overlap
+    builder.premultiply(false);
+    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "bc"]).unwrap();
+    dbg!(&dfa);
+    dfa.dbg();
+    let mut state = dfa.start_state();
+    let mut match_index = 0;
+    let input_idx = 0;
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
+    assert_eq!((2, 0), (input_idx, match_idx));
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
+    assert_eq!((3, 1), (input_idx, match_idx));
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
+    assert_eq!((3, 2), (input_idx, match_idx));
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
+    assert_eq!((5, 0), (input_idx, match_idx));
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
+    assert_eq!((6, 1), (input_idx, match_idx));
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
+    assert_eq!((6, 2), (input_idx, match_idx));
+    assert_eq!(None, dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index));
+    
 }

--- a/tests/suite.rs
+++ b/tests/suite.rs
@@ -332,7 +332,6 @@ fn multi_find() {
     builder.allow_invalid_utf8(true);
     //builder.anchored(true);
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
-    dfa.dbg();
     // @@awygle I'm not sure find actually has meaningful semantics for regex-set
     assert_eq!(Some(8), dfa.find(b"dddadddb"));
 
@@ -469,10 +468,6 @@ fn overlapping_find_at() {
         )
         .unwrap();
     assert_eq!((2, 0), (input_idx, match_idx));
-    println!("got one");
-    dbg!(input_idx);
-    dbg!(match_index);
-    dbg!(state);
     let (input_idx, match_idx) = dfa
         .overlapping_find_at(
             b"bababa",
@@ -482,7 +477,6 @@ fn overlapping_find_at() {
         )
         .unwrap();
     assert_eq!((4, 0), (input_idx, match_idx));
-    println!("got two");
     let (input_idx, match_idx) = dfa
         .overlapping_find_at(
             b"bababa",
@@ -492,7 +486,6 @@ fn overlapping_find_at() {
         )
         .unwrap();
     assert_eq!((6, 0), (input_idx, match_idx));
-    println!("got three");
     assert_eq!(
         None,
         dfa.overlapping_find_at(
@@ -579,7 +572,6 @@ fn overlapping_find_at() {
     let dfa = builder
         .build_multi_with_size::<usize>(vec!["ab", "bc", "abc"])
         .unwrap();
-    dfa.dbg();
     let mut state = dfa.start_state();
     let mut match_index = 0;
     let input_idx = 0;
@@ -592,7 +584,6 @@ fn overlapping_find_at() {
         )
         .unwrap();
     assert_eq!((2, 0), (input_idx, match_idx));
-    println!("one done");
     let (input_idx, match_idx) = dfa
         .overlapping_find_at(
             b"abcabc",
@@ -602,7 +593,6 @@ fn overlapping_find_at() {
         )
         .unwrap();
     assert_eq!((3, 1), (input_idx, match_idx));
-    println!("two done");
     let (input_idx, match_idx) = dfa
         .overlapping_find_at(
             b"abcabc",
@@ -612,7 +602,6 @@ fn overlapping_find_at() {
         )
         .unwrap();
     assert_eq!((3, 2), (input_idx, match_idx));
-    println!("three done");
     let (input_idx, match_idx) = dfa
         .overlapping_find_at(
             b"abcabc",
@@ -622,7 +611,6 @@ fn overlapping_find_at() {
         )
         .unwrap();
     assert_eq!((5, 0), (input_idx, match_idx));
-    println!("four done");
     let (input_idx, match_idx) = dfa
         .overlapping_find_at(
             b"abcabc",
@@ -632,7 +620,6 @@ fn overlapping_find_at() {
         )
         .unwrap();
     assert_eq!((6, 1), (input_idx, match_idx));
-    println!("five done");
     let (input_idx, match_idx) = dfa
         .overlapping_find_at(
             b"abcabc",
@@ -642,7 +629,6 @@ fn overlapping_find_at() {
         )
         .unwrap();
     assert_eq!((6, 2), (input_idx, match_idx));
-    println!("six done");
     assert_eq!(
         None,
         dfa.overlapping_find_at(
@@ -652,5 +638,4 @@ fn overlapping_find_at() {
             &mut match_index
         )
     );
-    println!("all done");
 }

--- a/tests/suite.rs
+++ b/tests/suite.rs
@@ -322,13 +322,20 @@ fn multi_find() {
     let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
     assert_eq!(Some(2), dfa.find(b"ba"));
     
+    // Multiple matching patterns
+    builder.premultiply(false);
+    builder.unicode(false);
+    builder.allow_invalid_utf8(true);
+    //builder.anchored(true);
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    dfa.dbg();
+    // @@awygle I'm not sure find actually has meaningful semantics for regex-set
+    assert_eq!(Some(8), dfa.find(b"dddadddb"));
+    
     // Same pattern multiple times
     let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
-    assert_eq!(Some(2), dfa.find(b"bababa"));
-    
-    // Multiple matching patterns
-    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
-    assert_eq!(Some(8), dfa.find(b"dddadddb"));
+    // @@awygle I'm not sure find actually has meaningful semantics for regex-set
+    assert_eq!(Some(6), dfa.find(b"bababa"));
     
     // First pattern matches
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
@@ -371,6 +378,7 @@ fn multi_rfind() {
     
     // Multiple matching patterns
     let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    // @@awygle I'm not sure rfind actually has meaningful semantics for regex-set
     assert_eq!(Some(3), dfa.rfind(b"dddadddb"));
     
     // First pattern matches
@@ -398,99 +406,110 @@ fn multi_rfind() {
 #[test]
 fn overlapping_find_at() {
     let mut builder = dense::Builder::new();
-    builder.reverse(true);
     
     // A single matching pattern
-//    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
-//    let mut state = dfa.start_state();
-//    let mut match_index = 0;
-//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"a", 0, &mut state, &mut match_index).unwrap();
-//    assert_eq!((1, 0), (input_idx, match_idx));
-//    assert_eq!(None, dfa.overlapping_find_at(b"a", input_idx, &mut state, &mut match_index));
-//    
-//    // A single non-matching pattern
-//    let dfa = builder.build_multi_with_size::<usize>(vec!["b"]).unwrap();
-//    let mut state = dfa.start_state();
-//    let mut match_index = 0;
-//    assert_eq!(None, dfa.overlapping_find_at(b"a", 0, &mut state, &mut match_index));
-//    
-//    // A single matching pattern not at start
-//    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
-//    let mut state = dfa.start_state();
-//    let mut match_index = 0;
-//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"ba", 0, &mut state, &mut match_index).unwrap();
-//    assert_eq!((2, 0), (input_idx, match_idx));
-//    assert_eq!(None, dfa.overlapping_find_at(b"ba", input_idx, &mut state, &mut match_index));
-//    
-//    // Same pattern multiple times
-//    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
-//    let mut state = dfa.start_state();
-//    let mut match_index = 0;
-//    let input_idx = 0;
-//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index).unwrap();
-//    assert_eq!((2, 0), (input_idx, match_idx));
-//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index).unwrap();
-//    assert_eq!((4, 0), (input_idx, match_idx));
-//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index).unwrap();
-//    assert_eq!((6, 0), (input_idx, match_idx));
-//    assert_eq!(None, dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index));
-//    
-//    // multiple matching patterns
-//    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
-//    let mut state = dfa.start_state();
-//    let mut match_index = 0;
-//    let input_idx = 0;
-//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"dddadddb", input_idx, &mut state, &mut match_index).unwrap();
-//    assert_eq!((4, 0), (input_idx, match_idx));
-//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"dddadddb", input_idx, &mut state, &mut match_index).unwrap();
-//    assert_eq!((8, 1), (input_idx, match_idx));
-//    assert_eq!(None, dfa.overlapping_find_at(b"dddadddb", input_idx, &mut state, &mut match_index));
-//    
-//    // First pattern matches
-//    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
-//    let mut state = dfa.start_state();
-//    let mut match_index = 0;
-//    let input_idx = 0;
-//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"a", input_idx, &mut state, &mut match_index).unwrap();
-//    assert_eq!((1, 0), (input_idx, match_idx));
-//    assert_eq!(None, dfa.overlapping_find_at(b"a", input_idx, &mut state, &mut match_index));
-//    
-//    // Second pattern matches
-//    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
-//    let mut state = dfa.start_state();
-//    let mut match_index = 0;
-//    let input_idx = 0;
-//    let (input_idx, match_idx) = dfa.overlapping_find_at(b"b", input_idx, &mut state, &mut match_index).unwrap();
-//    assert_eq!((1, 1), (input_idx, match_idx));
-//    assert_eq!(None, dfa.overlapping_find_at(b"b", input_idx, &mut state, &mut match_index));
-//    
-//    // Neither pattern matches
-//    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
-//    let mut state = dfa.start_state();
-//    let mut match_index = 0;
-//    let input_idx = 0;
-//    assert_eq!(None, dfa.overlapping_find_at(b"c", input_idx, &mut state, &mut match_index));
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+    let mut state = dfa.start_state();
+    let mut match_index = 0;
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"a", 0, &mut state, &mut match_index).unwrap();
+    assert_eq!((1, 0), (input_idx, match_idx));
+    assert_eq!(None, dfa.overlapping_find_at(b"a", input_idx, &mut state, &mut match_index));
+    
+    // A single non-matching pattern
+    let dfa = builder.build_multi_with_size::<usize>(vec!["b"]).unwrap();
+    let mut state = dfa.start_state();
+    let mut match_index = 0;
+    assert_eq!(None, dfa.overlapping_find_at(b"a", 0, &mut state, &mut match_index));
+    
+    // A single matching pattern not at start
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+    let mut state = dfa.start_state();
+    let mut match_index = 0;
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"ba", 0, &mut state, &mut match_index).unwrap();
+    assert_eq!((2, 0), (input_idx, match_idx));
+    assert_eq!(None, dfa.overlapping_find_at(b"ba", input_idx, &mut state, &mut match_index));
+    
+    // Same pattern multiple times
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a"]).unwrap();
+    let mut state = dfa.start_state();
+    let mut match_index = 0;
+    let input_idx = 0;
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index).unwrap();
+    assert_eq!((2, 0), (input_idx, match_idx));
+    println!("got one");
+    dbg!(input_idx);
+    dbg!(match_index);
+    dbg!(state);
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index).unwrap();
+    assert_eq!((4, 0), (input_idx, match_idx));
+    println!("got two");
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index).unwrap();
+    assert_eq!((6, 0), (input_idx, match_idx));
+    println!("got three");
+    assert_eq!(None, dfa.overlapping_find_at(b"bababa", input_idx, &mut state, &mut match_index));
+    
+    // multiple matching patterns
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    let mut state = dfa.start_state();
+    let mut match_index = 0;
+    let input_idx = 0;
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"dddadddb", input_idx, &mut state, &mut match_index).unwrap();
+    assert_eq!((4, 0), (input_idx, match_idx));
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"dddadddb", input_idx, &mut state, &mut match_index).unwrap();
+    assert_eq!((8, 1), (input_idx, match_idx));
+    assert_eq!(None, dfa.overlapping_find_at(b"dddadddb", input_idx, &mut state, &mut match_index));
+    
+    // First pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    let mut state = dfa.start_state();
+    let mut match_index = 0;
+    let input_idx = 0;
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"a", input_idx, &mut state, &mut match_index).unwrap();
+    assert_eq!((1, 0), (input_idx, match_idx));
+    assert_eq!(None, dfa.overlapping_find_at(b"a", input_idx, &mut state, &mut match_index));
+    
+    // Second pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    let mut state = dfa.start_state();
+    let mut match_index = 0;
+    let input_idx = 0;
+    let (input_idx, match_idx) = dfa.overlapping_find_at(b"b", input_idx, &mut state, &mut match_index).unwrap();
+    assert_eq!((1, 1), (input_idx, match_idx));
+    assert_eq!(None, dfa.overlapping_find_at(b"b", input_idx, &mut state, &mut match_index));
+    
+    // Neither pattern matches
+    let dfa = builder.build_multi_with_size::<usize>(vec!["a", "b"]).unwrap();
+    let mut state = dfa.start_state();
+    let mut match_index = 0;
+    let input_idx = 0;
+    assert_eq!(None, dfa.overlapping_find_at(b"c", input_idx, &mut state, &mut match_index));
     
     // Legit overlap
     builder.premultiply(false);
-    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "bc"]).unwrap();
-    dbg!(&dfa);
+    let dfa = builder.build_multi_with_size::<usize>(vec!["ab", "bc", "abc"]).unwrap();
     dfa.dbg();
     let mut state = dfa.start_state();
     let mut match_index = 0;
     let input_idx = 0;
     let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
     assert_eq!((2, 0), (input_idx, match_idx));
+    println!("one done");
     let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
     assert_eq!((3, 1), (input_idx, match_idx));
+    println!("two done");
     let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
     assert_eq!((3, 2), (input_idx, match_idx));
+    println!("three done");
     let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
     assert_eq!((5, 0), (input_idx, match_idx));
+    println!("four done");
     let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
     assert_eq!((6, 1), (input_idx, match_idx));
+    println!("five done");
     let (input_idx, match_idx) = dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index).unwrap();
     assert_eq!((6, 2), (input_idx, match_idx));
+    println!("six done");
     assert_eq!(None, dfa.overlapping_find_at(b"abcabc", input_idx, &mut state, &mut match_index));
+    println!("all done");
     
 }


### PR DESCRIPTION
This is a work-in-progress, but I felt it was to a point where it was worth discussing. This specific PR is focused entirely on DFAs, implementing multiple-pattern functionality up to the point of `overlapping_find_at`.

The biggest issues I have currently are with the semantics of `find` for multiple-pattern regexes. I'm not sure what it should do, especially if it's unanchored.

Please take a look, let me know what you think of the overall approach, point out any obvious mistakes, etc.

Known work to go:

- [ ] More test cases
- [ ] Fix serialization/deserialization
- [ ] Support non-allocating versions of the match map (AsRef a bunch of things)

Intended, eventually, to close #4 