### PR TITLE
Replace `#[doc(hidden)] __Nonexhaustive` with `#[non_exhaustive]`

### DIFF
--- a/src/dense.rs
+++ b/src/dense.rs
@@ -139,6 +139,7 @@ pub(crate) const MASK_ANCHORED: u16 = 0b0000_0000_0000_0010;
 /// the variants of this DFA and use each variant's implementation of the `DFA`
 /// trait directly.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum DenseDFA<T: AsRef<[S]>, S: StateID> {
     /// A standard DFA that does not use premultiplication or byte classes.
     Standard(Standard<T, S>),
@@ -162,13 +163,6 @@ pub enum DenseDFA<T: AsRef<[S]>, S: StateID> {
     /// The default configuration of a DFA, which uses byte classes and
     /// premultiplies its state identifiers.
     PremultipliedByteClass(PremultipliedByteClass<T, S>),
-    /// Hints that destructuring should not be exhaustive.
-    ///
-    /// This enum may grow additional variants, so this makes sure clients
-    /// don't count on exhaustive matching. (Otherwise, adding a new variant
-    /// could break existing code.)
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl<T: AsRef<[S]>, S: StateID> DenseDFA<T, S> {
@@ -181,7 +175,6 @@ impl<T: AsRef<[S]>, S: StateID> DenseDFA<T, S> {
             DenseDFA::ByteClass(ref r) => &r.0,
             DenseDFA::Premultiplied(ref r) => &r.0,
             DenseDFA::PremultipliedByteClass(ref r) => &r.0,
-            DenseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -256,7 +249,6 @@ impl<T: AsRef<[S]>, S: StateID> DenseDFA<T, S> {
                 let inner = PremultipliedByteClass(r.0.as_ref());
                 DenseDFA::PremultipliedByteClass(inner)
             }
-            DenseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -282,7 +274,6 @@ impl<T: AsRef<[S]>, S: StateID> DenseDFA<T, S> {
                 let inner = PremultipliedByteClass(r.0.to_owned());
                 DenseDFA::PremultipliedByteClass(inner)
             }
-            DenseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -538,7 +529,6 @@ impl<S: StateID> DenseDFA<Vec<S>, S> {
             DenseDFA::ByteClass(ref mut r) => &mut r.0,
             DenseDFA::Premultiplied(ref mut r) => &mut r.0,
             DenseDFA::PremultipliedByteClass(ref mut r) => &mut r.0,
-            DenseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -580,7 +570,6 @@ impl<T: AsRef<[S]>, S: StateID> DFA for DenseDFA<T, S> {
             DenseDFA::PremultipliedByteClass(ref r) => {
                 r.next_state(current, input)
             }
-            DenseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -599,7 +588,6 @@ impl<T: AsRef<[S]>, S: StateID> DFA for DenseDFA<T, S> {
             DenseDFA::PremultipliedByteClass(ref r) => {
                 r.next_state_unchecked(current, input)
             }
-            DenseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -617,7 +605,6 @@ impl<T: AsRef<[S]>, S: StateID> DFA for DenseDFA<T, S> {
             DenseDFA::PremultipliedByteClass(ref r) => {
                 r.is_match_at(bytes, start)
             }
-            DenseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -632,7 +619,6 @@ impl<T: AsRef<[S]>, S: StateID> DFA for DenseDFA<T, S> {
             DenseDFA::PremultipliedByteClass(ref r) => {
                 r.shortest_match_at(bytes, start)
             }
-            DenseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -643,7 +629,6 @@ impl<T: AsRef<[S]>, S: StateID> DFA for DenseDFA<T, S> {
             DenseDFA::ByteClass(ref r) => r.find_at(bytes, start),
             DenseDFA::Premultiplied(ref r) => r.find_at(bytes, start),
             DenseDFA::PremultipliedByteClass(ref r) => r.find_at(bytes, start),
-            DenseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -656,7 +641,6 @@ impl<T: AsRef<[S]>, S: StateID> DFA for DenseDFA<T, S> {
             DenseDFA::PremultipliedByteClass(ref r) => {
                 r.rfind_at(bytes, start)
             }
-            DenseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -106,6 +106,7 @@ use state_id::{dead_id, StateID};
 /// the variants of this DFA and use each variant's implementation of the `DFA`
 /// trait directly.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum SparseDFA<T: AsRef<[u8]>, S: StateID = usize> {
     /// A standard DFA that does not use byte classes.
     Standard(Standard<T, S>),
@@ -121,13 +122,6 @@ pub enum SparseDFA<T: AsRef<[u8]>, S: StateID = usize> {
     /// reason for this is that a sparse DFA already compacts each state's
     /// transitions separate from whether byte classes are used.
     ByteClass(ByteClass<T, S>),
-    /// Hints that destructuring should not be exhaustive.
-    ///
-    /// This enum may grow additional variants, so this makes sure clients
-    /// don't count on exhaustive matching. (Otherwise, adding a new variant
-    /// could break existing code.)
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 #[cfg(feature = "std")]
@@ -203,7 +197,6 @@ impl<T: AsRef<[u8]>, S: StateID> SparseDFA<T, S> {
             SparseDFA::ByteClass(ByteClass(ref r)) => {
                 SparseDFA::ByteClass(ByteClass(r.as_ref()))
             }
-            SparseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -222,7 +215,6 @@ impl<T: AsRef<[u8]>, S: StateID> SparseDFA<T, S> {
             SparseDFA::ByteClass(ByteClass(ref r)) => {
                 SparseDFA::ByteClass(ByteClass(r.to_owned()))
             }
-            SparseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -242,7 +234,6 @@ impl<T: AsRef<[u8]>, S: StateID> SparseDFA<T, S> {
         match *self {
             SparseDFA::Standard(ref r) => &r.0,
             SparseDFA::ByteClass(ref r) => &r.0,
-            SparseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -445,7 +436,6 @@ impl<T: AsRef<[u8]>, S: StateID> DFA for SparseDFA<T, S> {
         match *self {
             SparseDFA::Standard(ref r) => r.next_state(current, input),
             SparseDFA::ByteClass(ref r) => r.next_state(current, input),
-            SparseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -466,7 +456,6 @@ impl<T: AsRef<[u8]>, S: StateID> DFA for SparseDFA<T, S> {
         match *self {
             SparseDFA::Standard(ref r) => r.is_match_at(bytes, start),
             SparseDFA::ByteClass(ref r) => r.is_match_at(bytes, start),
-            SparseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -475,7 +464,6 @@ impl<T: AsRef<[u8]>, S: StateID> DFA for SparseDFA<T, S> {
         match *self {
             SparseDFA::Standard(ref r) => r.shortest_match_at(bytes, start),
             SparseDFA::ByteClass(ref r) => r.shortest_match_at(bytes, start),
-            SparseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -484,7 +472,6 @@ impl<T: AsRef<[u8]>, S: StateID> DFA for SparseDFA<T, S> {
         match *self {
             SparseDFA::Standard(ref r) => r.find_at(bytes, start),
             SparseDFA::ByteClass(ref r) => r.find_at(bytes, start),
-            SparseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -493,7 +480,6 @@ impl<T: AsRef<[u8]>, S: StateID> DFA for SparseDFA<T, S> {
         match *self {
             SparseDFA::Standard(ref r) => r.rfind_at(bytes, start),
             SparseDFA::ByteClass(ref r) => r.rfind_at(bytes, start),
-            SparseDFA::__Nonexhaustive => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
Using the [`#[non_exhaustive]`](https://doc.rust-lang.org/stable/reference/attributes/type_system.html#the-non_exhaustive-attribute), you can remove the `__Nonexhaustive` varient of `DenseDFA` and `SparseDFA`.

## Advantages:
- Ensures the compiler enforces the non-exhaustive nature of the enums, rather than relying on `#[doc(hidden)]`.

## Disadvantages
-  `#[non_exhaustive]` requires [rust 1.40](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#non_exhaustive-structs-enums-and-variants) or above.

This will not break code that has wildcard arm in all matches (which is must unless it explicitly matches against `__Nonexhaustive` in which case it will be broken if and when more variants are added. However, it will break codebases that compile with rust 1.39 or lower.