### PR TITLE
Add DFA::{find_iter, rfind_iter} for working on iterators.

### DIFF
--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -265,22 +265,27 @@ pub trait DFA {
         if self.is_anchored() && start > 0 {
             return None;
         }
+        self.find_iter(bytes[start..].iter().cloned()).map(|n| start + n)
+    }
 
+    /// Same as find, but takes an iterator as input
+    #[inline]
+    fn find_iter(&self, bytes: impl Iterator<Item=u8>) -> Option<usize> {
         let mut state = self.start_state();
         let mut last_match = if self.is_dead_state(state) {
             return None;
         } else if self.is_match_state(state) {
-            Some(start)
+            Some(0)
         } else {
             None
         };
-        for (i, &b) in bytes[start..].iter().enumerate() {
+        for (i, b) in bytes.enumerate() {
             state = unsafe { self.next_state_unchecked(state, b) };
             if self.is_match_or_dead_state(state) {
                 if self.is_dead_state(state) {
                     return last_match;
                 }
-                last_match = Some(start + i + 1);
+                last_match = Some(i + 1);
             }
         }
         last_match
@@ -298,21 +303,26 @@ pub trait DFA {
             return None;
         }
 
+        self.rfind_iter(bytes[..start].iter().rev().cloned()).map(|n| start - n)
+    }
+
+    /// like find, but returns the number of bytes in the reverse direction
+    fn rfind_iter(&self, bytes: impl Iterator<Item=u8>) -> Option<usize> {
         let mut state = self.start_state();
         let mut last_match = if self.is_dead_state(state) {
             return None;
         } else if self.is_match_state(state) {
-            Some(start)
+            Some(0)
         } else {
             None
         };
-        for (i, &b) in bytes[..start].iter().enumerate().rev() {
+        for (i, b) in bytes.enumerate() {
             state = unsafe { self.next_state_unchecked(state, b) };
             if self.is_match_or_dead_state(state) {
                 if self.is_dead_state(state) {
                     return last_match;
                 }
-                last_match = Some(i);
+                last_match = Some(i + 1);
             }
         }
         last_match

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -268,7 +268,7 @@ pub trait DFA {
         self.find_iter(bytes[start..].iter().cloned()).map(|n| start + n)
     }
 
-    /// Same as find, but takes an iterator as input
+    /// Returns the same as find, but takes an iterator as input.
     #[inline]
     fn find_iter(&self, bytes: impl Iterator<Item=u8>) -> Option<usize> {
         let mut state = self.start_state();
@@ -306,7 +306,7 @@ pub trait DFA {
         self.rfind_iter(bytes[..start].iter().rev().cloned()).map(|n| start - n)
     }
 
-    /// like find, but returns the number of bytes in the reverse direction
+    /// Works like rfind, but returns the number of bytes in the reverse direction and takes an iterator input.
     fn rfind_iter(&self, bytes: impl Iterator<Item=u8>) -> Option<usize> {
         let mut state = self.start_state();
         let mut last_match = if self.is_dead_state(state) {

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -327,6 +327,11 @@ impl<D: DFA> Regex<D> {
         Matches::new(self, input)
     }
 
+    /// create a forward searcher capable of accepting a stream
+    pub fn find_stream(&self) -> MatchesStream<D> {
+        MatchesStream::new(self.forward())
+    }
+
     /// Build a new regex from its constituent forward and reverse DFAs.
     ///
     /// This is useful when deserializing a regex from some arbitrary
@@ -451,6 +456,56 @@ impl<'r, 't, D: DFA> Iterator for Matches<'r, 't, D> {
         }
         self.last_match = Some(e);
         Some((s, e))
+    }
+}
+
+struct MatchStreamState<D: DFA> {
+    start: usize,
+    id: D::ID,
+    was_match: bool,
+}
+pub struct MatchesStream<'r, D: DFA> {
+    dfa: &'r D,
+
+    /// list of live DFA IDs to match against each input and the input position when they started
+    live: Vec<MatchStreamState<D>>,
+
+    // input stream position
+    position: usize,
+}
+impl<'r, D: DFA> MatchesStream<'r, D> {
+    fn new(dfa: &'r D) -> Self {
+        MatchesStream {
+            dfa,
+            live: Vec::new(),
+            position: 0
+        }
+    }
+    pub fn advance(&mut self, input: u8) {
+        // add new state
+        if self.position == 0 || !self.dfa.is_anchored() {
+            self.live.push(MatchStreamState {
+                start: self.position,
+                id: self.dfa.start_state(),
+                was_match: false
+            });
+        }
+
+        // remove dead states
+        let dfa = &self.dfa;
+        self.live.retain(|state| !dfa.is_dead_state(state.id));
+
+        // progress all existing DFA state
+        for state in self.live.iter_mut() {
+            state.was_match = self.dfa.is_match_state(state.id);
+            state.id = self.dfa.next_state(state.id, input);
+        }
+
+        self.position += 1;
+    }
+
+    pub fn matches(&self) -> impl Iterator<Item=(usize, usize)> + '_ {
+        self.live.iter().filter(|state| state.was_match).map(move |state| (state.start, self.position))
     }
 }
 


### PR DESCRIPTION
One does not always have a slice of data to work with.
`find_iter` and `rfind_iter` provide a loophole to use iterators instead.