### PR TITLE
Remove byteorder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ std = ["regex-syntax"]
 transducer = ["std", "fst"]
 
 [dependencies]
-byteorder = { version = "1.2.7", default-features = false }
 fst = { version = "0.4.0", optional = true }
 regex-syntax = { version = "0.6.16", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ configuring the best space vs time trade off for your use case and provides
 support for cheap deserialization of automata for use in `no_std` environments.
 
 [![Build status](https://github.com/BurntSushi/regex-automata/workflows/ci/badge.svg)](https://github.com/BurntSushi/regex-automata/actions)
-[![](https://meritbadge.herokuapp.com/regex-automata)](https://crates.io/crates/regex-automata)
+[![on crates.io](https://meritbadge.herokuapp.com/regex-automata)](https://crates.io/crates/regex-automata)
+![Minimum Supported Rust Version 1.40](https://img.shields.io/badge/rustc-1.40-red)
 
 Dual-licensed under MIT or the [UNLICENSE](https://unlicense.org/).
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.40.0"

--- a/src/byte.rs
+++ b/src/byte.rs
@@ -1,0 +1,77 @@
+use core::convert::TryInto;
+use core::mem::size_of;
+pub trait Endian {
+    fn read_u16(buf: &[u8]) -> u16;
+    fn read_u32(buf: &[u8]) -> u32;
+    fn read_u64(buf: &[u8]) -> u64;
+    fn read_usize(buf: &[u8]) -> usize;
+    fn write_u16(buf: &mut [u8], n: u16);
+    fn write_u32(buf: &mut [u8], n: u32);
+    fn write_u64(buf: &mut [u8], n: u64);
+    fn write_usize(buf: &mut [u8], n: usize);
+}
+
+pub enum BigEndian {}
+pub enum LittleEndian {}
+pub enum NativeEndian {}
+
+macro_rules! impl_endian {
+    ($t:ty, $from_endian:ident, $to_endian:ident) => {
+        impl Endian for $t {
+            #[inline]
+            fn read_u16(buf: &[u8]) -> u16 {
+                u16::$from_endian(buf[0..2].try_into().unwrap())
+            }
+
+            #[inline]
+            fn read_u32(buf: &[u8]) -> u32 {
+                u32::$from_endian(buf[0..4].try_into().unwrap())
+            }
+
+            #[inline]
+            fn read_u64(buf: &[u8]) -> u64 {
+                u64::$from_endian(buf[0..8].try_into().unwrap())
+            }
+
+            #[inline]
+            fn read_usize(buf: &[u8]) -> usize {
+                usize::$from_endian(
+                    buf[0..size_of::<usize>()].try_into().unwrap(),
+                )
+            }
+
+            #[inline]
+            fn write_u16(buf: &mut [u8], n: u16) {
+                buf[0..2].copy_from_slice(&n.$to_endian()[..]);
+            }
+
+            #[inline]
+            fn write_u32(buf: &mut [u8], n: u32) {
+                buf[0..4].copy_from_slice(&n.$to_endian()[..]);
+            }
+
+            #[inline]
+            fn write_u64(buf: &mut [u8], n: u64) {
+                buf[0..8].copy_from_slice(&n.$to_endian()[..]);
+            }
+
+            #[inline]
+            fn write_usize(buf: &mut [u8], n: usize) {
+                buf[0..size_of::<usize>()]
+                    .copy_from_slice(&n.$to_endian()[..]);
+            }
+        }
+    };
+}
+
+impl_endian! {
+    BigEndian, from_be_bytes, to_be_bytes
+}
+
+impl_endian! {
+    LittleEndian, from_le_bytes, to_le_bytes
+}
+
+impl_endian! {
+    NativeEndian, from_ne_bytes, to_ne_bytes
+}

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -6,8 +6,9 @@ use core::mem;
 use core::slice;
 
 #[cfg(feature = "std")]
-use byteorder::{BigEndian, LittleEndian};
-use byteorder::{ByteOrder, NativeEndian};
+use crate::byte::{BigEndian, LittleEndian};
+use crate::byte::{Endian, NativeEndian};
+
 #[cfg(feature = "std")]
 use regex_syntax::ParserBuilder;
 
@@ -1202,7 +1203,7 @@ impl<T: AsRef<[S]>, S: StateID> Repr<T, S> {
     /// implementations of `StateID` provided by this crate satisfy this
     /// requirement.
     #[cfg(feature = "std")]
-    pub(crate) fn to_bytes<A: ByteOrder>(&self) -> Result<Vec<u8>> {
+    pub(crate) fn to_bytes<A: Endian>(&self) -> Result<Vec<u8>> {
         let label = b"rust-regex-automata-dfa\x00";
         assert_eq!(24, label.len());
 
@@ -1210,7 +1211,7 @@ impl<T: AsRef<[S]>, S: StateID> Repr<T, S> {
         let size =
             // For human readable label.
             label.len()
-            // endiannes check, must be equal to 0xFEFF for native endian
+            // endianness check, must be equal to 0xFEFF for native endian
             + 2
             // For version number.
             + 2

--- a/src/determinize.rs
+++ b/src/determinize.rs
@@ -148,7 +148,8 @@ impl<'a, S: StateID> Determinizer<'a, S> {
         if let Some(&cached_id) = self.cache.get(&state) {
             // Since we have a cached state, put the constructed state's
             // memory back into our scratch space, so that it can be reused.
-            mem::replace(&mut self.scratch_nfa_states, state.nfa_states);
+            let _ =
+                mem::replace(&mut self.scratch_nfa_states, state.nfa_states);
             return Ok((cached_id, false));
         }
         // Nothing was in the cache, so add this state to the cache.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,6 @@ extern crate core;
 
 #[cfg(all(test, feature = "transducer"))]
 extern crate bstr;
-extern crate byteorder;
 #[cfg(feature = "transducer")]
 extern crate fst;
 #[cfg(feature = "std")]
@@ -306,6 +305,7 @@ pub use regex::RegexBuilder;
 pub use sparse::SparseDFA;
 pub use state_id::StateID;
 
+mod byte;
 mod classes;
 #[path = "dense.rs"]
 mod dense_imp;

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -8,8 +8,8 @@ use core::mem::size_of;
 use std::collections::HashMap;
 
 #[cfg(feature = "std")]
-use byteorder::{BigEndian, LittleEndian};
-use byteorder::{ByteOrder, NativeEndian};
+use crate::byte::{BigEndian, LittleEndian};
+use crate::byte::{Endian, NativeEndian};
 
 use classes::ByteClasses;
 use dense;
@@ -765,7 +765,7 @@ impl<T: AsRef<[u8]>, S: StateID> Repr<T, S> {
     /// Unlike dense DFAs, the result is not necessarily aligned since a
     /// sparse DFA's transition table is always read as a sequence of bytes.
     #[cfg(feature = "std")]
-    fn to_bytes<A: ByteOrder>(&self) -> Result<Vec<u8>> {
+    fn to_bytes<A: Endian>(&self) -> Result<Vec<u8>> {
         let label = b"rust-regex-automata-sparse-dfa\x00";
         let size =
             // For human readable label.

--- a/src/state_id.rs
+++ b/src/state_id.rs
@@ -1,15 +1,14 @@
 use core::fmt::Debug;
 use core::hash::Hash;
-use core::mem::size_of;
 
-use byteorder::{ByteOrder, NativeEndian};
+use crate::byte::{Endian, NativeEndian};
 
 #[cfg(feature = "std")]
 pub use self::std::*;
 
 #[cfg(feature = "std")]
 mod std {
-    use byteorder::ByteOrder;
+    use crate::byte::Endian;
     use core::mem::size_of;
     use error::{Error, Result};
 
@@ -63,7 +62,7 @@ mod std {
     /// `size_of::<S>()`.
     ///
     /// The given state identifier representation must have size 1, 2, 4 or 8.
-    pub fn write_state_id_bytes<E: ByteOrder, S: StateID>(
+    pub fn write_state_id_bytes<E: Endian, S: StateID>(
         slice: &mut [u8],
         id: S,
     ) {
@@ -171,12 +170,12 @@ unsafe impl StateID for usize {
 
     #[inline]
     fn read_bytes(slice: &[u8]) -> Self {
-        NativeEndian::read_uint(slice, size_of::<usize>()) as usize
+        NativeEndian::read_usize(slice)
     }
 
     #[inline]
     fn write_bytes(self, slice: &mut [u8]) {
-        NativeEndian::write_uint(slice, self as u64, size_of::<usize>())
+        NativeEndian::write_usize(slice, self)
     }
 }
 


### PR DESCRIPTION
This PR removes byteorder, formally raises the MSRV to 1.40.0 (according to a run of [cargo msrv](https://crates.io/crates/cargo-msrv)), and adds a rust-toolchain file in order to control MSRV drift.

Closes #12.