### PR TITLE
remove byteorder, redux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ std = ["regex-syntax"]
 transducer = ["std", "fst"]
 
 [dependencies]
-byteorder = { version = "1.2.7", default-features = false }
 fst = { version = "0.4.0", optional = true }
 regex-syntax = { version = "0.6.16", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ configuring the best space vs time trade off for your use case and provides
 support for cheap deserialization of automata for use in `no_std` environments.
 
 [![Build status](https://github.com/BurntSushi/regex-automata/workflows/ci/badge.svg)](https://github.com/BurntSushi/regex-automata/actions)
-[![](https://meritbadge.herokuapp.com/regex-automata)](https://crates.io/crates/regex-automata)
+[![on crates.io](https://meritbadge.herokuapp.com/regex-automata)](https://crates.io/crates/regex-automata)
+![Minimum Supported Rust Version 1.41](https://img.shields.io/badge/rustc-1.41-green)
 
 Dual-licensed under MIT or the [UNLICENSE](https://unlicense.org/).
 

--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -1,0 +1,76 @@
+use core::convert::TryInto;
+
+pub trait ByteOrder {
+    fn read_u16(buf: &[u8]) -> u16;
+    fn read_u32(buf: &[u8]) -> u32;
+    fn read_u64(buf: &[u8]) -> u64;
+    fn read_uint(buf: &[u8], nbytes: usize) -> u64;
+    fn write_u16(buf: &mut [u8], n: u16);
+    fn write_u32(buf: &mut [u8], n: u32);
+    fn write_u64(buf: &mut [u8], n: u64);
+    fn write_uint(buf: &mut [u8], n: u64, nbytes: usize);
+}
+
+pub enum BigEndian {}
+pub enum LittleEndian {}
+pub enum NativeEndian {}
+
+macro_rules! impl_endian {
+    ($t:ty, $from_endian:ident, $to_endian:ident) => {
+        impl ByteOrder for $t {
+            #[inline]
+            fn read_u16(buf: &[u8]) -> u16 {
+                u16::$from_endian(buf[0..2].try_into().unwrap())
+            }
+
+            #[inline]
+            fn read_u32(buf: &[u8]) -> u32 {
+                u32::$from_endian(buf[0..4].try_into().unwrap())
+            }
+
+            #[inline]
+            fn read_u64(buf: &[u8]) -> u64 {
+                u64::$from_endian(buf[0..8].try_into().unwrap())
+            }
+
+            #[inline]
+            fn read_uint(buf: &[u8], nbytes: usize) -> u64 {
+                let mut dst = [0u8; 8];
+                dst[..nbytes].copy_from_slice(&buf[..nbytes]);
+                u64::$from_endian(dst)
+            }
+
+            #[inline]
+            fn write_u16(buf: &mut [u8], n: u16) {
+                buf[0..2].copy_from_slice(&n.$to_endian()[..]);
+            }
+
+            #[inline]
+            fn write_u32(buf: &mut [u8], n: u32) {
+                buf[0..4].copy_from_slice(&n.$to_endian()[..]);
+            }
+
+            #[inline]
+            fn write_u64(buf: &mut [u8], n: u64) {
+                buf[0..8].copy_from_slice(&n.$to_endian()[..]);
+            }
+
+            #[inline]
+            fn write_uint(buf: &mut [u8], n: u64, nbytes: usize) {
+                buf[..nbytes].copy_from_slice(&n.$to_endian()[..nbytes]);
+            }
+        }
+    };
+}
+
+impl_endian! {
+    BigEndian, from_be_bytes, to_be_bytes
+}
+
+impl_endian! {
+    LittleEndian, from_le_bytes, to_le_bytes
+}
+
+impl_endian! {
+    NativeEndian, from_ne_bytes, to_ne_bytes
+}

--- a/src/determinize.rs
+++ b/src/determinize.rs
@@ -148,7 +148,8 @@ impl<'a, S: StateID> Determinizer<'a, S> {
         if let Some(&cached_id) = self.cache.get(&state) {
             // Since we have a cached state, put the constructed state's
             // memory back into our scratch space, so that it can be reused.
-            mem::replace(&mut self.scratch_nfa_states, state.nfa_states);
+            let _ =
+                mem::replace(&mut self.scratch_nfa_states, state.nfa_states);
             return Ok((cached_id, false));
         }
         // Nothing was in the cache, so add this state to the cache.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,6 @@ extern crate core;
 
 #[cfg(all(test, feature = "transducer"))]
 extern crate bstr;
-extern crate byteorder;
 #[cfg(feature = "transducer")]
 extern crate fst;
 #[cfg(feature = "std")]
@@ -306,6 +305,7 @@ pub use regex::RegexBuilder;
 pub use sparse::SparseDFA;
 pub use state_id::StateID;
 
+mod byteorder;
 mod classes;
 #[path = "dense.rs"]
 mod dense_imp;


### PR DESCRIPTION
This is like #15, but shrinks the diff considerably to make rebasing my rewrite easier. This also gets rid of the Rust toolchain file.