### PR TITLE
Update dependencies in test/cli, and fix a compile error in test.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ memchr = { version = "2.4.0", default-features = false }
 regex-syntax = { version = "0.6.24", optional = true }
 
 [dev-dependencies]
-bstr = { version = "0.2.16", default-features = false, features = ["std"] }
+bstr = { version = "1.0.1", default-features = false, features = ["std"] }
 quickcheck = { version = "1.0.3", default-features = false }
 regex-syntax = "0.6.16"
 regex-test = { version = "*", path = "regex-test" }

--- a/regex-cli/Cargo.toml
+++ b/regex-cli/Cargo.toml
@@ -20,9 +20,9 @@ name = "regex-cli"
 
 [dependencies]
 anyhow = "1.0.28"
-bstr = { version = "0.2.16", default-features = false, features = ["std"] }
+bstr = { version = "1.0.1", default-features = false, features = ["std"] }
 clap = { version = "2.33.0", default-features = false }
-memmap2 = "0.3.0"
+memmap2 = "0.5.8"
 regex = "1.5.4"
 syntax = { package = "regex-syntax", version = "0.6.17" }
 tabwriter = "1.2.1"
@@ -34,6 +34,6 @@ path = ".."
 features = ["logging"]
 
 [dependencies.env_logger]
-version = "0.8.4"
+version = "0.10.0"
 default-features = false
-features = ["atty", "humantime", "termcolor"]
+features = ["auto-color", "humantime", "color"]

--- a/regex-cli/Cargo.toml
+++ b/regex-cli/Cargo.toml
@@ -21,7 +21,7 @@ name = "regex-cli"
 [dependencies]
 anyhow = "1.0.28"
 bstr = { version = "1.0.1", default-features = false, features = ["std"] }
-clap = { version = "2.33.0", default-features = false }
+clap = { version = "4.0.29", default-features = false, features = ["std", "cargo", "help", "error-context", "usage"] }
 memmap2 = "0.5.8"
 regex = "1.5.4"
 syntax = { package = "regex-syntax", version = "0.6.17" }

--- a/regex-cli/src/app.rs
+++ b/regex-cli/src/app.rs
@@ -14,7 +14,7 @@ SUBCOMMANDS:
 {subcommands}
 
 OPTIONS:
-{unified}";
+{options}";
 
 const TEMPLATE_SUBCOMMAND: &'static str = "\
 USAGE:
@@ -27,7 +27,7 @@ SUBCOMMANDS:
 {subcommands}
 
 OPTIONS:
-{unified}";
+{options}";
 
 const TEMPLATE_LEAF: &'static str = "\
 USAGE:
@@ -40,7 +40,7 @@ ARGS:
 {positionals}
 
 OPTIONS:
-{unified}";
+{options}";
 
 const ABOUT: &'static str = "
 regex-cli is a tool for interacting with regular expressions on the command
@@ -50,20 +50,19 @@ code.
 ";
 
 /// Convenience type alias for the Clap app type that we use.
-pub type App = clap::App<'static, 'static>;
+pub type App = clap::Command;
 
 /// Convenience type alias for the Clap argument result type that we use.
-pub type Args = clap::ArgMatches<'static>;
+pub type Args = clap::ArgMatches;
 
 /// Convenience function for creating a new Clap sub-command.
 ///
 /// This should be used for sub-commands that contain other sub-commands.
 pub fn command(name: &'static str) -> App {
-    clap::SubCommand::with_name(name)
+    clap::Command::new(name)
         .author(clap::crate_authors!())
         .version(clap::crate_version!())
-        .template(TEMPLATE_SUBCOMMAND)
-        .setting(clap::AppSettings::UnifiedHelpMessage)
+        .help_template(TEMPLATE_SUBCOMMAND)
 }
 
 /// Convenience function for creating a new Clap sub-command.
@@ -71,41 +70,39 @@ pub fn command(name: &'static str) -> App {
 /// This should be used for sub-commands that do NOT contain other
 /// sub-commands.
 pub fn leaf(name: &'static str) -> App {
-    clap::SubCommand::with_name(name)
+    clap::Command::new(name)
         .author(clap::crate_authors!())
         .version(clap::crate_version!())
-        .template(TEMPLATE_LEAF)
-        .setting(clap::AppSettings::UnifiedHelpMessage)
+        .help_template(TEMPLATE_LEAF)
 }
 
 /// Convenience function for defining a Clap positional argument with the
 /// given name.
 pub fn arg(name: &'static str) -> clap::Arg {
-    clap::Arg::with_name(name)
+    clap::Arg::new(name)
 }
 
 /// Convenience function for defining a Clap argument with a long flag name
 /// that accepts a single value.
 pub fn flag(name: &'static str) -> clap::Arg {
-    clap::Arg::with_name(name).long(name).takes_value(true)
+    clap::Arg::new(name).long(name)
 }
 
 /// Convenience function for defining a Clap argument with a long flag name
 /// that accepts no values. i.e., It is a boolean switch.
 pub fn switch(name: &'static str) -> clap::Arg {
-    clap::Arg::with_name(name).long(name)
+    clap::Arg::new(name).long(name).action(clap::ArgAction::SetTrue)
 }
 
 /// Build the main Clap application.
 pub fn root() -> App {
-    clap::App::new("regex-cli")
+    clap::Command::new("regex-cli")
         .author(clap::crate_authors!())
         .version(clap::crate_version!())
         .about(ABOUT)
-        .template(TEMPLATE_ROOT)
+        .help_template(TEMPLATE_ROOT)
         .max_term_width(100)
-        .setting(clap::AppSettings::UnifiedHelpMessage)
-        .arg(switch("quiet").short("q").global(true).help("Show less output."))
+        .arg(switch("quiet").short('q').global(true).help("Show less output."))
         .subcommand(cmd::debug::define())
         .subcommand(cmd::find::define())
 }

--- a/regex-cli/src/cmd/debug.rs
+++ b/regex-cli/src/cmd/debug.rs
@@ -139,7 +139,7 @@ fn run_ast(args: &Args) -> anyhow::Result<()> {
         let (ast, time_ast) = util::timeitr(|| csyntax.ast(&p))?;
         table.add("parse time", time_ast);
         table.print(stdout())?;
-        if !args.is_present("quiet") {
+        if !args.get_flag("quiet") {
             writeln!(stdout(), "\n{:#?}", ast)?;
         }
     }
@@ -162,7 +162,7 @@ fn run_hir(args: &Args) -> anyhow::Result<()> {
         let (hir, time_hir) = util::timeitr(|| csyntax.hir(&p, &ast))?;
         table.add("translate time", time_hir);
         table.print(stdout())?;
-        if !args.is_present("quiet") {
+        if !args.get_flag("quiet") {
             writeln!(stdout(), "\n{:#?}", hir)?;
         }
     }
@@ -193,7 +193,7 @@ fn run_nfa_thompson(args: &Args) -> anyhow::Result<()> {
     table.add("pattern count", nfa.pattern_len());
     table.add("capture count", nfa.capture_len());
     table.print(stdout())?;
-    if !args.is_present("quiet") {
+    if !args.get_flag("quiet") {
         writeln!(stdout(), "\n{:?}", nfa)?;
     }
     Ok(())
@@ -220,7 +220,7 @@ fn run_dfa_dense(args: &Args) -> anyhow::Result<()> {
         &mut table, &csyntax, &cthompson, &cdense, &patterns,
     )?;
     table.print(stdout())?;
-    if !args.is_present("quiet") {
+    if !args.get_flag("quiet") {
         writeln!(stdout(), "\n{:?}", dfa)?;
     }
     Ok(())
@@ -238,7 +238,7 @@ fn run_dfa_sparse(args: &Args) -> anyhow::Result<()> {
         &mut table, &csyntax, &cthompson, &cdense, &patterns,
     )?;
     table.print(stdout())?;
-    if !args.is_present("quiet") {
+    if !args.get_flag("quiet") {
         writeln!(stdout(), "\n{:?}", dfa)?;
     }
     Ok(())
@@ -265,7 +265,7 @@ fn run_dfa_regex_dense(args: &Args) -> anyhow::Result<()> {
         &mut table, &csyntax, &cthompson, &cdense, &patterns,
     )?;
     table.print(stdout())?;
-    if !args.is_present("quiet") {
+    if !args.get_flag("quiet") {
         writeln!(stdout(), "\n{:?}", re)?;
     }
     Ok(())
@@ -284,7 +284,7 @@ fn run_dfa_regex_sparse(args: &Args) -> anyhow::Result<()> {
         &mut table, &csyntax, &cthompson, &cdense, &patterns,
     )?;
     table.print(stdout())?;
-    if !args.is_present("quiet") {
+    if !args.get_flag("quiet") {
         writeln!(stdout(), "\n{:?}", sre)?;
     }
     Ok(())
@@ -312,7 +312,7 @@ fn run_hybrid_dense(args: &Args) -> anyhow::Result<()> {
     // TODO: This whole thing seems like a mess. What happens if someone wants
     // to customize how this works? Maybe "viewing the state of the cache"
     // should be an option for the 'find' sub-command? Ick.
-    if !args.is_present("quiet") {
+    if !args.get_flag("quiet") {
         writeln!(stdout(), "\n{:?}", idfa)?;
     }
     Ok(())
@@ -330,7 +330,7 @@ fn run_hybrid_regex(args: &Args) -> anyhow::Result<()> {
     let re = cregex
         .from_patterns(&mut table, &csyntax, &cthompson, &cdfa, &patterns)?;
     table.print(stdout())?;
-    if !args.is_present("quiet") {
+    if !args.get_flag("quiet") {
         writeln!(stdout(), "\n{:?}", re)?;
     }
     Ok(())

--- a/regex-cli/src/cmd/find.rs
+++ b/regex-cli/src/cmd/find.rs
@@ -161,7 +161,7 @@ fn run_api_regex(args: &Args) -> anyhow::Result<()> {
     let mut table = Table::empty();
 
     let csyntax = config::Syntax::get(args)?;
-    let cthompson = config::Thompson::get(args)?;
+    // let cthompson = config::Thompson::get(args)?;
     let cregex = config::RegexAPI::get(args)?;
     let input = config::Input::get(args)?;
     let patterns = config::Patterns::get(args)?;

--- a/regex-cli/src/main.rs
+++ b/regex-cli/src/main.rs
@@ -15,3 +15,11 @@ fn main() -> anyhow::Result<()> {
         _ => Err(util::UnrecognizedCommandError.into()),
     })
 }
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn verify_app() {
+        super::app::root().debug_assert();
+    }
+}

--- a/regex-cli/src/util.rs
+++ b/regex-cli/src/util.rs
@@ -28,13 +28,15 @@ pub fn run_subcommand(
     app: impl FnOnce() -> App,
     run: impl FnOnce(&str, &Args) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
-    let (name, args) = args.subcommand();
-    if name.is_empty() || args.is_none() {
-        app().print_help()?;
-        writeln!(std::io::stdout(), "")?;
-        return Ok(());
-    }
-    let err = match run(name, args.unwrap()) {
+    let (name, args) = match args.subcommand() {
+        Some((name, args)) if !name.is_empty() => (name, args),
+        _ => {
+            app().print_help()?;
+            writeln!(std::io::stdout())?;
+            return Ok(());
+        }
+    };
+    let err = match run(name, args) {
         Ok(()) => return Ok(()),
         Err(err) => err,
     };

--- a/regex-test/Cargo.toml
+++ b/regex-test/Cargo.toml
@@ -22,6 +22,6 @@ bench = false
 
 [dependencies]
 anyhow = "1.0.27"
-bstr = { version = "0.2.16", default-features = false, features = ["std", "serde1"] }
+bstr = { version = "1.0.1", default-features = false, features = ["std", "serde"] }
 serde = { version = "1.0.105", features = ["derive"] }
 toml = "0.5.6"

--- a/regex-test/src/lib.rs
+++ b/regex-test/src/lib.rs
@@ -1338,8 +1338,8 @@ matches = [[0, 2], [5, 10]]
         assert_eq!(
             t0.matches(),
             Some(vec![
-                Match { start: 0, end: 2 },
-                Match { start: 5, end: 10 },
+                Match { start: 0, end: 2, id: 0 },
+                Match { start: 5, end: 10, id: 0 },
             ])
         );
         assert_eq!(t0.captures(), None);
@@ -1368,23 +1368,23 @@ captures = [
         assert_eq!(
             t0.matches(),
             Some(vec![
-                Match { start: 0, end: 15 },
-                Match { start: 20, end: 30 },
+                Match { start: 0, end: 15, id: 0 },
+                Match { start: 20, end: 30, id: 0 },
             ])
         );
         assert_eq!(
             t0.captures(),
             Some(vec![
                 Captures::new(vec![
-                    Some(Match { start: 0, end: 15 }),
-                    Some(Match { start: 5, end: 10 }),
+                    Some(Match { start: 0, end: 15, id: 0 }),
+                    Some(Match { start: 5, end: 10, id: 0 }),
                     None,
-                    Some(Match { start: 13, end: 14 }),
+                    Some(Match { start: 13, end: 14, id: 0 }),
                 ]),
                 Captures::new(vec![
-                    Some(Match { start: 20, end: 30 }),
-                    Some(Match { start: 22, end: 24 }),
-                    Some(Match { start: 25, end: 27 }),
+                    Some(Match { start: 20, end: 30, id: 0 }),
+                    Some(Match { start: 22, end: 24, id: 0 }),
+                    Some(Match { start: 25, end: 27, id: 0 }),
                     None,
                 ]),
             ])


### PR DESCRIPTION
While hacking some stuff together in regex-automata for another project, I happened to fix a compilation error in the tests and also updated some of the dependencies in the cli and tests. Most notably clap (which is nontrivial to update), since I probably wouldn't bother upstreaming this otherwise.

In case you haven't used it in other projects, note that the newer versions of clap have a much less forgiving builder API (e.g. fail at runtime for some easily-made mistakes in a way that's annoying to test). In particular, if the initialization/declaration of a flag/option/arg isn't correct for how it's accessed, it will fail when you access it. I've (hopefully) manually tested that all the usage is correct so I'm mostly just saying this as a caveat for future extensions to that code, since it's not obvious.

These are purely changes to `regex-cli` and `regex-test` so they shouldn't be public at all. You may want to tweak/reduce the clap usage/features further (that said, note that new clap doesn't allow `default-features=false`), this is just the path of least resistance for the most part.